### PR TITLE
Fix the node/r bug on macOS

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,2 @@
 #!/usr/bin/env node
-
 require("../dist/index");

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/index');
+require("../dist/index");


### PR DESCRIPTION
My settings are set to
```
git config --global core.autocrlf true
```

I removed the line and saved the file and now things work. In projects that rely on indefinitely-typed, I have added my fork to resolutions to override this specific dependency. I think the difference is that git will autoresolve the lf/crlf issue, but npm won't, so packages downloaded there will still have the issue. If a CI build uses it locally, then it won't be an issue, but if it pulls from npm, then I think things break.

Not entirely sure.