### PR TITLE
Remove crlf from line endings in CLI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/*.js eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# include test stuff
+!test/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # include test stuff
 !test/node_modules
+
+# but not test output
+test/node_modules/@types

--- a/bin/cli2.js
+++ b/bin/cli2.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../dist/index");

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc -p ./src",
     "watch": "tsc -p ./src -w",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd test/node_modules/test && node ../../../bin/cli2.js --folder test-package-typings && node ../@types/test-package-typings/test-package/success.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "DefinitelyTyped"
   ],
   "bin": {
-    "indefinitely-typed": "./bin/cli.js"
+    "indefinitely-typed": "./bin/cli2.js"
   },
   "main": "dist/index.js",
   "files": [

--- a/test/node_modules/test/package.json
+++ b/test/node_modules/test/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "indefinitely-typed-test-package",
+    "private": true,
+    "version": "1.0.0",
+    "license": "MIT",
+    "types": "index.d.ts"
+  }
+  

--- a/test/node_modules/test/test-package-typings/test-package/index.d.ts
+++ b/test/node_modules/test/test-package-typings/test-package/index.d.ts
@@ -1,0 +1,1 @@
+declare const TestPackage: {};

--- a/test/node_modules/test/test-package-typings/test-package/success.js
+++ b/test/node_modules/test/test-package-typings/test-package/success.js
@@ -1,0 +1,1 @@
+console.log('success');


### PR DESCRIPTION
Created a new file `cli2.js` which uses only `lf` instead of `crlf`. Did this online through the GitHub UI to avoid Windows adding it back again.

cc @jkelleyrtp 